### PR TITLE
Add --random-shiny flag to name subcommand

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -70,6 +70,10 @@ struct Name {
     #[clap(short, long, default_value = "regular", value_parser = Form::from_str)]
     form: Form,
 
+    /// Randomize shininess with configured rate.
+    #[clap(long)]
+    random_shiny: bool,
+
     #[clap(flatten)]
     common: CommonArgs,
 }

--- a/src/pokemon.rs
+++ b/src/pokemon.rs
@@ -191,11 +191,7 @@ impl PokemonDatabase {
             ));
         }
 
-        let shiny = if name.random_shiny {
-            rand::thread_rng().gen_bool(self.config.shiny_rate) || name.common.shiny
-        } else {
-            name.common.shiny
-        };
+        let shiny = (name.random_shiny && rand::thread_rng().gen_bool(self.config.shiny_rate)) || name.common.shiny;
 
         let art_path = pokemon.get_art_path(&name.form, shiny)?;
 

--- a/src/pokemon.rs
+++ b/src/pokemon.rs
@@ -191,7 +191,13 @@ impl PokemonDatabase {
             ));
         }
 
-        let art_path = pokemon.get_art_path(&name.form, name.common.shiny)?;
+        let shiny = if name.random_shiny {
+            rand::thread_rng().gen_bool(self.config.shiny_rate) || name.common.shiny
+        } else {
+            name.common.shiny
+        };
+
+        let art_path = pokemon.get_art_path(&name.form, shiny)?;
 
         let art = Asset::get(&art_path)
             .unwrap_or_else(|| panic!("Could not read pokemon art from '{}'", art_path))
@@ -267,6 +273,7 @@ impl PokemonDatabase {
                 no_title: random.common.no_title,
                 padding_left: random.common.padding_left,
             },
+            random_shiny: false,
         })
     }
 }
@@ -379,6 +386,7 @@ mod tests {
                 no_title: false,
                 padding_left: 0,
             },
+            random_shiny: false,
         };
 
         assert!(db.show_pokemon_by_name(&name).is_ok());


### PR DESCRIPTION
Basically the title, added a flag to allow the random shiny feature from the `random` subcommand to work in `name` too.

I wanted to make sure that the functionality would remain the same for old users who don't watch for updates, so I didn't want to add the functionality by default and make the flag disable it.

Literally my first PR, I'm sorry if it sucks, I know it's not the prettiest code in the world, please be patient with me lol